### PR TITLE
Fix config read/write for workshop maps

### DIFF
--- a/DevZones (CORE PLUGIN)/scripting/devzones.sp
+++ b/DevZones (CORE PLUGIN)/scripting/devzones.sp
@@ -329,13 +329,13 @@ public void ReadZones() {
 	if (!DirExists(Path))
 		CreateDirectory(Path, 0777);
 	
+	char wsPath[512];
+	BuildPath(Path_SM, wsPath, sizeof(wsPath), "configs/dev_zones/workshop");
+	if (!DirExists(wsPath))
+		CreateDirectory(wsPath, 0777);
+	
 	char map[64];
 	GetCurrentMap(map, sizeof(map));
-	if (StrContains(map, "workshop") != -1) {
-		char mapPart[3][64];
-		ExplodeString(map, "/", mapPart, 3, 64);
-		strcopy(map, sizeof(map), mapPart[2]);
-	}
 	StringToLowerCase(map);
 	BuildPath(Path_SM, Path, sizeof(Path), "configs/dev_zones/%s.zones.txt", map);
 	if (!FileExists(Path))
@@ -378,11 +378,6 @@ public void SaveZones(int client) {
 	char Path[512];
 	char map[64];
 	GetCurrentMap(map, sizeof(map));
-	if (StrContains(map, "workshop") != -1) {
-		char mapPart[3][64];
-		ExplodeString(map, "/", mapPart, 3, 64);
-		strcopy(map, sizeof(map), mapPart[2]);
-	}
 	StringToLowerCase(map);
 	BuildPath(Path_SM, Path, sizeof(Path), "configs/dev_zones/%s.zones.txt", map);
 	Handle file = OpenFile(Path, "w+");


### PR DESCRIPTION
Due to a bug, the plugin fails to find config files for workshop maps and tries to read/write to a file called ``.zones``.

This PR removes the blocks that were supposed to split the map name for workshop maps, as they never worked in the first place. Instead, a ``workshop`` directory is now created.
Since ``GetCurrentMap`` automatically returns something like ``workshop/surf_venice_v3e.ugc678241315`` for workshop maps, devzones will now create a config file ``configs/dev_zones/workshop/surf_venice_v3e.ugc678241315.zones``.